### PR TITLE
[Patch] Only existing Field values can be fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=wlchs_SudOOku&metric=alert_status)](https://sonarcloud.io/dashboard?id=wlchs_SudOOku)
 
 Object-oriented Sudoku solver ~~& generator~~
+#### Version: 1.0.1
 
 ## Solver
 - implemented

--- a/sudooku_src/sudooku_core/exceptions/CMakeLists.txt
+++ b/sudooku_src/sudooku_core/exceptions/CMakeLists.txt
@@ -4,4 +4,6 @@ add_library(
         noStrategiesException.h
         noMatrixException.cpp
         noMatrixException.h
+        fieldDoesntContainValueException.cpp
+        fieldDoesntContainValueException.h
 )

--- a/sudooku_src/sudooku_core/exceptions/fieldDoesntContainValueException.cpp
+++ b/sudooku_src/sudooku_core/exceptions/fieldDoesntContainValueException.cpp
@@ -1,0 +1,9 @@
+//
+// Created by Borbély László on 2018. 11. 08..
+//
+
+#include "fieldDoesntContainValueException.h"
+
+const char *FieldDoesntContainValueException::what() const noexcept {
+    return "Field doesn't contain passed value!";
+}

--- a/sudooku_src/sudooku_core/exceptions/fieldDoesntContainValueException.h
+++ b/sudooku_src/sudooku_core/exceptions/fieldDoesntContainValueException.h
@@ -1,0 +1,16 @@
+//
+// Created by Borbély László on 2018. 11. 08..
+//
+
+#ifndef SUDOOKU_FIELDDOESNTCONTAINVALUEEXCEPTION_H
+#define SUDOOKU_FIELDDOESNTCONTAINVALUEEXCEPTION_H
+
+#include <exception>
+
+class FieldDoesntContainValueException : public std::exception {
+public:
+    const char *what() const noexcept override;
+};
+
+
+#endif //SUDOOKU_FIELDDOESNTCONTAINVALUEEXCEPTION_H

--- a/sudooku_src/sudooku_core/matrix/field.cpp
+++ b/sudooku_src/sudooku_core/matrix/field.cpp
@@ -5,6 +5,7 @@
 #include "field.h"
 #include "matrix.h"
 #include <algorithm>
+#include <exceptions/fieldDoesntContainValueException.h>
 
 /**
  * Initialize Field with a set of possible values
@@ -51,7 +52,10 @@ void Field::fixValue() {
  * @param value
  */
 void Field::fixValue(unsigned short const int value) {
-    /* TODO: Check if the value passed as a parameter is a member of possibleValues. If not: throw an exception */
+    /* Check if the value passed as a parameter is a member of possibleValues. If not: throw an exception */
+    if (!contains(value)) {
+        throw FieldDoesntContainValueException{};
+    }
 
     /* Remove all elements of the vector */
     possibleValues.clear();

--- a/sudooku_src/sudooku_core/matrix/field.cpp
+++ b/sudooku_src/sudooku_core/matrix/field.cpp
@@ -82,8 +82,6 @@ void Field::removeValue() {
  * @return
  */
 bool Field::removeValue(unsigned short const int value) {
-    /* TODO: contains function can be reused here */
-
     /* Try to find value in the vector */
     auto it = std::find(std::begin(possibleValues), std::end(possibleValues), value);
 

--- a/sudooku_tests/controller_tests/fileOutputHandlerTest.cpp
+++ b/sudooku_tests/controller_tests/fileOutputHandlerTest.cpp
@@ -58,6 +58,9 @@ TEST_F(FileOutputHandlerTests, matrix_write_invalid_test) {
     /* Try sending a solution notification with a nullpointer */
     try {
         outputHandler->notifyEvent(SudookuEvent::SOLUTION, nullptr);
+
+        /* If the execution reaches this point, the test failed */
+        FAIL() << "An exception of type NoMatrixProvidedException should have been thrown!";
     }
 
         /* A specific exception should be thrown in this case */
@@ -78,6 +81,9 @@ TEST_F(FileOutputHandlerTests, invalid_event_test) {
     /* Try sending a notification with the event type of '-1' */
     try {
         outputHandler->notifyEvent(static_cast<SudookuEvent>(-1), nullptr);
+
+        /* If the execution reaches this point, the test failed */
+        FAIL() << "An exception of type WrongEventTypeException should have been thrown!";
     }
 
         /* A specific exception should be thrown in this case */

--- a/sudooku_tests/core_tests/matrix_tests/fieldTest.cpp
+++ b/sudooku_tests/core_tests/matrix_tests/fieldTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <sudooku_core/matrix/field.h>
 #include <vector>
+#include <sudooku_core/exceptions/fieldDoesntContainValueException.h>
 
 /**
  * Field test fixture class
@@ -69,6 +70,29 @@ TEST_F(FieldTests, fixvalue_witharg_test) {
 
     /* The value should be the value passed */
     ASSERT_EQ(3, f1.getPossibleValues()[0]);
+}
+
+/**
+ * Test case for the fixValue(...) method, which should throw an exception when called with an incorrent value
+ */
+TEST_F(FieldTests, fixvalue_witharg_invalid_test) {
+    /* Try executing method */
+    try {
+        f1.fixValue(999);
+
+        /* If the execution reaches this point, the test failed */
+        FAIL() << "An exception of type FieldDoesntContainValueException should have been thrown!";
+    }
+
+        /* Should throw exception type FieldDoesntContainValueException */
+    catch (FieldDoesntContainValueException &e) {
+        EXPECT_EQ(std::string{"Field doesn't contain passed value!"}, e.what());
+    }
+
+        /* Should fail otherwise */
+    catch (...) {
+        FAIL() << "FieldDoesntContainValueException expected!";
+    }
 }
 
 /**

--- a/sudooku_tests/core_tests/solver_tests/solverTest.cpp
+++ b/sudooku_tests/core_tests/solver_tests/solverTest.cpp
@@ -159,6 +159,9 @@ TEST_F(SolverTests, solve_empty_strategies_test) {
     try {
         /* Execute solving method */
         solver.solve();
+
+        /* If the execution reaches this point, the test failed */
+        FAIL() << "NoStrategiesException should have been thrown";
     }
 
         /* A specific type of exception should be thrown */
@@ -183,6 +186,9 @@ TEST_F(SolverTests, solve_empty_matrix_test) {
     try {
         /* Execute solving method */
         solver.solve();
+
+        /* If the execution reaches this point, the test failed */
+        FAIL() << "NoMatrixException should have been thrown";
     }
 
         /* A specific type of exception should be thrown */


### PR DESCRIPTION
Field should throw an exception if fixValue(...) is called with a parameter which isn't a member of the potential values.