### PR TITLE
[Patch] InputStrategy refactored for memory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=wlchs_SudOOku&metric=alert_status)](https://sonarcloud.io/dashboard?id=wlchs_SudOOku)
 
 Object-oriented Sudoku solver ~~& generator~~
-#### Version: 1.2
+#### Version: 1.2.1
 
 ## Solver
 - implemented

--- a/sudooku_src/sudooku_controller/handlers/input_handlers/fileInputHandler.cpp
+++ b/sudooku_src/sudooku_controller/handlers/input_handlers/fileInputHandler.cpp
@@ -13,7 +13,8 @@
  * Open input file with the given name
  * @param fileName
  */
-FileInputHandler::FileInputHandler(std::vector<bool> const &flags_, std::string const &fileName) : flags(flags_) {
+FileInputHandler::FileInputHandler(std::vector<SolvingStrategy *> const &rules_, std::string const &fileName) : rules(
+        rules_) {
     /* Open input */
     inputFile.open(fileName);
 
@@ -46,18 +47,8 @@ Matrix FileInputHandler::readInput() {
  * The pointers allocated must be freed by the caller
  * @return solving strategies
  */
-std::vector<SolvingStrategy *> FileInputHandler::readRules() {
-    /* Allocate SolvingStrategy pointers */
-    std::vector<SolvingStrategy *> rules = {
-            new RowStrategy{},
-            new ColumnStrategy{},
-            new GroupStrategy{}};
-
-    /* The allocation of DiagonalStrategy is optional */
-    if (flags[0]) {
-        rules.push_back(new DiagonalStrategy{});
-    }
-
+std::vector<SolvingStrategy *> const &FileInputHandler::readRules() {
+    /* Return SolvingStrategy * vector */
     return rules;
 }
 

--- a/sudooku_src/sudooku_controller/handlers/input_handlers/fileInputHandler.h
+++ b/sudooku_src/sudooku_controller/handlers/input_handlers/fileInputHandler.h
@@ -18,16 +18,16 @@ class FileInputHandler : public InputHandler {
 private:
     std::ifstream inputFile;
     ReadMatrixFromFile *readMatrixFromFile;
-    std::vector<bool> flags{};
+    std::vector<SolvingStrategy *> rules{};
 
 public:
-    explicit FileInputHandler(std::vector<bool> const &, std::string const &);
+    explicit FileInputHandler(std::vector<SolvingStrategy *> const &, std::string const &);
 
     ~FileInputHandler() override;
 
     Matrix readInput() override;
 
-    std::vector<SolvingStrategy *> readRules() override;
+    std::vector<SolvingStrategy *> const &readRules() override;
 
     bool hasInput() const override;
 };

--- a/sudooku_src/sudooku_controller/handlers/input_handlers/inputHandler.h
+++ b/sudooku_src/sudooku_controller/handlers/input_handlers/inputHandler.h
@@ -22,7 +22,7 @@ public:
 
     virtual Matrix readInput() = 0;
 
-    virtual std::vector<SolvingStrategy *> readRules() = 0;
+    virtual std::vector<SolvingStrategy *> const &readRules() = 0;
 };
 
 #endif //SUDOOKU_INPUTHANDLER_H

--- a/sudooku_src/sudooku_controller/sudookuController.cpp
+++ b/sudooku_src/sudooku_controller/sudookuController.cpp
@@ -70,13 +70,3 @@ void SudookuController::initializeSolver() {
     /* Initialize solver */
     solver->setRules(rules);
 }
-
-/**
- * Delete manually allocated solving strategies
- */
-SudookuController::~SudookuController() {
-    for (auto *rule : rules) {
-        delete rule;
-        rule = nullptr;
-    }
-}

--- a/sudooku_src/sudooku_controller/sudookuController.h
+++ b/sudooku_src/sudooku_controller/sudookuController.h
@@ -27,7 +27,7 @@ private:
 public:
     SudookuController(InputHandler *, OutputHandler *, Solver *);
 
-    ~SudookuController();
+    ~SudookuController() = default;
 
     void run();
 };

--- a/sudooku_tests/controller_tests/fileInputHandlerTest.cpp
+++ b/sudooku_tests/controller_tests/fileInputHandlerTest.cpp
@@ -5,6 +5,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <sudooku_controller/handlers/input_handlers/fileInputHandler.h>
+#include <sudooku_core/strategies/rowStrategy.h>
+#include <sudooku_core/strategies/columnStrategy.h>
+#include <sudooku_core/strategies/groupStrategy.h>
 
 /**
  * FileInputHandler test fixture class
@@ -12,13 +15,14 @@
 class FileInputHandlerTests : public ::testing::Test {
 protected:
     InputHandler *inputHandler{};
+    std::vector<SolvingStrategy *> solvingStrategies = {new RowStrategy{}, new ColumnStrategy{}, new GroupStrategy{}};
 
     /**
      * Setup method running before the execution of each test case
      */
     void SetUp() override {
         /* Initialize FileInputHandler object */
-        inputHandler = new FileInputHandler{{false}, "small1.mat"};
+        inputHandler = new FileInputHandler{solvingStrategies, "small1.mat"};
     }
 
     /**
@@ -27,6 +31,12 @@ protected:
     void TearDown() override {
         /* Free InputHandler object to prevent memory leak */
         delete inputHandler;
+
+        /* Deallocate SolvingStrategy pointers */
+        for (SolvingStrategy *solvingStrategy : solvingStrategies) {
+            /* Delete object */
+            delete solvingStrategy;
+        }
     }
 };
 

--- a/sudooku_tests/controller_tests/helper_classes/mockInputHandler.h
+++ b/sudooku_tests/controller_tests/helper_classes/mockInputHandler.h
@@ -17,7 +17,7 @@ public:
 
     MOCK_METHOD0(readInput, Matrix());
 
-    MOCK_METHOD0(readRules, std::vector<SolvingStrategy *>());
+    MOCK_METHOD0(readRules, std::vector<SolvingStrategy *>const &());
 };
 
 #endif //SUDOOKU_MOCKINPUTHANDLER_H

--- a/sudooku_tests/core_tests/matrix_tests/forkHelperTest.cpp
+++ b/sudooku_tests/core_tests/matrix_tests/forkHelperTest.cpp
@@ -4,6 +4,9 @@
 
 #include <gtest/gtest.h>
 #include <sudooku_controller/handlers/input_handlers/fileInputHandler.h>
+#include <sudooku_core/strategies/rowStrategy.h>
+#include <sudooku_core/strategies/columnStrategy.h>
+#include <sudooku_core/strategies/groupStrategy.h>
 
 /**
  * ForkHelper test fixture class
@@ -12,13 +15,14 @@ class ForkHelperTests : public ::testing::Test {
 protected:
     Matrix m1;
     ForkHelper *forkHelper{};
+    std::vector<SolvingStrategy *> solvingStrategies = {new RowStrategy{}, new ColumnStrategy{}, new GroupStrategy{}};
 
     /**
      * Setup method running before the execution of each test case
      */
     void SetUp() override {
         /* Read input Matrix from file */
-        m1 = FileInputHandler{{false}, "small4.mat"}.readInput();
+        m1 = FileInputHandler{solvingStrategies, "small4.mat"}.readInput();
 
         /* Remove one value so that the ForkHelper class chooses that value as the optimal forking Field */
         m1[{4, 4}].removeValue(4);
@@ -33,6 +37,12 @@ protected:
     void TearDown() override {
         /* Free ForkHelper object to prevent memory leak */
         delete forkHelper;
+
+        /* Deallocate SolvingStrategy pointers */
+        for (SolvingStrategy *solvingStrategy : solvingStrategies) {
+            /* Delete object */
+            delete solvingStrategy;
+        }
     }
 };
 

--- a/sudooku_tests/core_tests/matrix_tests/matrixTest.cpp
+++ b/sudooku_tests/core_tests/matrix_tests/matrixTest.cpp
@@ -5,6 +5,9 @@
 #include <gtest/gtest.h>
 #include <sudooku_core/matrix/matrix.h>
 #include <sudooku_controller/handlers/input_handlers/fileInputHandler.h>
+#include <sudooku_core/strategies/rowStrategy.h>
+#include <sudooku_core/strategies/columnStrategy.h>
+#include <sudooku_core/strategies/groupStrategy.h>
 
 /**
  * Matrix test fixture class
@@ -12,13 +15,25 @@
 class MatrixTests : public ::testing::Test {
 protected:
     Matrix m1;
+    std::vector<SolvingStrategy *> solvingStrategies = {new RowStrategy{}, new ColumnStrategy{}, new GroupStrategy{}};
 
     /**
      * Setup method running before the execution of each test case
      */
     void SetUp() override {
         /* Read input Matrix from file */
-        m1 = FileInputHandler{{false}, "small4.mat"}.readInput();
+        m1 = FileInputHandler{solvingStrategies, "small4.mat"}.readInput();
+    }
+
+    /**
+     * Teardown method running after the execution of each test case
+     */
+    void TearDown() override {
+        /* Deallocate SolvingStrategy pointers */
+        for (SolvingStrategy *solvingStrategy : solvingStrategies) {
+            /* Delete object */
+            delete solvingStrategy;
+        }
     }
 };
 
@@ -92,7 +107,7 @@ TEST_F(MatrixTests, fork_test) {
  */
 TEST_F(MatrixTests, equality_operator_true_check) {
     /* Read the initial Matrix again */
-    Matrix m11 = FileInputHandler{{false}, "small4.mat"}.readInput();
+    Matrix m11 = FileInputHandler{solvingStrategies, "small4.mat"}.readInput();
 
     /* Since the two sources are the same, the Matrixes should be equal too */
     EXPECT_EQ(m1, m11);
@@ -104,7 +119,7 @@ TEST_F(MatrixTests, equality_operator_true_check) {
  */
 TEST_F(MatrixTests, equality_operator_false_check) {
     /* Read another Matrix from file */
-    Matrix m2 = FileInputHandler{{false}, "small3.mat"}.readInput();
+    Matrix m2 = FileInputHandler{solvingStrategies, "small3.mat"}.readInput();
 
     /* Since the two read Matrices were different, the operator should return false */
     EXPECT_NE(m1, m2);
@@ -116,7 +131,7 @@ TEST_F(MatrixTests, equality_operator_false_check) {
  */
 TEST_F(MatrixTests, equality_operator_dimension_false_check) {
     /* Read another Matrix from file */
-    Matrix m2 = FileInputHandler{{false}, "small3.mat"}.readInput();
+    Matrix m2 = FileInputHandler{solvingStrategies, "small3.mat"}.readInput();
 
     /* Even the dimensions don't match, so the function should return false before starting to check each
      * value individually */

--- a/sudooku_tests/core_tests/solver_tests/solverTest.cpp
+++ b/sudooku_tests/core_tests/solver_tests/solverTest.cpp
@@ -20,6 +20,7 @@ protected:
     Solver s1;
     std::vector<SolvingStrategy *> rules;
 
+
     /**
      * Setup method running before the execution of each test case
      */
@@ -40,7 +41,7 @@ protected:
      */
     void TearDown() override {
         /* Since there is no controller to free the pointers, we have to do it on our own */
-        for (auto &p : rules) {
+        for (auto *p : rules) {
             delete p;
         }
     }
@@ -51,7 +52,7 @@ protected:
  */
 TEST_F(SolverTests, small_solvable_test) {
     /* Initialize puzzle */
-    Matrix matrix = FileInputHandler{{false}, "small1.mat"}.readInput();
+    Matrix matrix = FileInputHandler{rules, "small1.mat"}.readInput();
 
     /* Set it as the initial Matrix of the Solver */
     s1.setInitialMatrix(matrix);
@@ -71,7 +72,7 @@ TEST_F(SolverTests, small_solvable_test) {
  */
 TEST_F(SolverTests, small_not_solvable_test) {
     /* Initialize puzzle */
-    Matrix matrix = FileInputHandler{{false}, "invalid1.mat"}.readInput();
+    Matrix matrix = FileInputHandler{rules, "invalid1.mat"}.readInput();
 
     /* Set it as the initial Matrix of the Solver */
     s1.setInitialMatrix(matrix);
@@ -91,7 +92,7 @@ TEST_F(SolverTests, small_not_solvable_test) {
  */
 TEST_F(SolverTests, each_solution_is_unique_test) {
     /* Initialize puzzle */
-    Matrix matrix = FileInputHandler{{false}, "test3.mat"}.readInput();
+    Matrix matrix = FileInputHandler{rules, "test3.mat"}.readInput();
 
     /* Set it as the initial Matrix of the Solver */
     s1.setInitialMatrix(matrix);
@@ -130,7 +131,7 @@ TEST_F(SolverTests, diagonal_test) {
     s1.addRule(diagonalStrategy);
 
     /* Read input puzzle */
-    Matrix matrix = FileInputHandler{{false}, "test5.mat"}.readInput();
+    Matrix matrix = FileInputHandler{rules, "test5.mat"}.readInput();
 
     /* Set it as the initial Matrix of the Solver */
     s1.setInitialMatrix(matrix);

--- a/sudooku_tests/core_tests/strategy_tests/columnStrategyTest.cpp
+++ b/sudooku_tests/core_tests/strategy_tests/columnStrategyTest.cpp
@@ -2,7 +2,9 @@
 // Created by Borbély László on 2018. 10. 16..
 //
 
+#include <sudooku_core/strategies/rowStrategy.h>
 #include <sudooku_core/strategies/columnStrategy.h>
+#include <sudooku_core/strategies/groupStrategy.h>
 #include <sudooku_controller/handlers/input_handlers/fileInputHandler.h>
 #include <sudooku_core/matrix/matrix.h>
 #include "gtest/gtest.h"
@@ -14,18 +16,30 @@ class ColumnStrategyTests : public ::testing::Test {
 protected:
     ColumnStrategy columnStrategy;
     Matrix m1;
+    std::vector<SolvingStrategy *> solvingStrategies = {new RowStrategy{}, new ColumnStrategy{}, new GroupStrategy{}};
 
     /**
      * Setup method running before the execution of each test case
      */
     void SetUp() override {
         /* Initialize input Matrix */
-        m1 = FileInputHandler{{false}, "small1.mat"}.readInput();
+        m1 = FileInputHandler{solvingStrategies, "small1.mat"}.readInput();
 
         /* Remove some values to test column strategy functionality */
         m1[{1, 2}].removeValue(4);
         m1[{2, 2}].removeValue(4);
         m1[{3, 2}].removeValue(4);
+    }
+
+    /**
+     * Teardown method running after the execution of each test case
+     */
+    void TearDown() override {
+        /* Deallocate SolvingStrategy pointers */
+        for (SolvingStrategy *solvingStrategy : solvingStrategies) {
+            /* Delete object */
+            delete solvingStrategy;
+        }
     }
 };
 
@@ -35,7 +49,7 @@ protected:
  */
 TEST_F(ColumnStrategyTests, validation_check_false) {
     /* Initialize input Matrix */
-    Matrix invalid = FileInputHandler{{false}, "invalid1.mat"}.readInput();
+    Matrix invalid = FileInputHandler{solvingStrategies, "invalid1.mat"}.readInput();
 
     /* Check validity
      * Should return false */

--- a/sudooku_tests/core_tests/strategy_tests/diagonalStrategyTest.cpp
+++ b/sudooku_tests/core_tests/strategy_tests/diagonalStrategyTest.cpp
@@ -2,6 +2,9 @@
 // Created by Borbély László on 2018. 10. 21..
 //
 
+#include <sudooku_core/strategies/rowStrategy.h>
+#include <sudooku_core/strategies/columnStrategy.h>
+#include <sudooku_core/strategies/groupStrategy.h>
 #include <sudooku_core/strategies/diagonalStrategy.h>
 #include <sudooku_controller/handlers/input_handlers/fileInputHandler.h>
 #include "gtest/gtest.h"
@@ -11,18 +14,23 @@
  */
 class DiagonalStrategyTests : public ::testing::Test {
 protected:
-    SolvingStrategy *diagonalStrategy = nullptr;
+    DiagonalStrategy *diagonalStrategy = new DiagonalStrategy{};
     Matrix m1;
+    std::vector<SolvingStrategy *> solvingStrategies = {
+            new RowStrategy{},
+            new ColumnStrategy{},
+            new GroupStrategy{},
+    };
 
     /**
      * Setup method running before the execution of each test case
      */
     void SetUp() override {
-        /* Initialize DiagonalStrategy */
-        diagonalStrategy = new DiagonalStrategy{};
+        /* Add DiagonalStrategy * to vector */
+        solvingStrategies.push_back(diagonalStrategy);
 
         /* Initialize input Matrix */
-        m1 = FileInputHandler{{false}, "small4.mat"}.readInput();
+        m1 = FileInputHandler{solvingStrategies, "small4.mat"}.readInput();
 
         /* Remove some values to test diagonal strategy functionality */
         m1[{1, 1}].removeValue(4);
@@ -34,8 +42,11 @@ protected:
      * Teardown method running after the execution of each test case
      */
     void TearDown() override {
-        /* Free DiagonalStrategy object to prevent memory leak */
-        delete diagonalStrategy;
+        /* Deallocate SolvingStrategy pointers */
+        for (SolvingStrategy *solvingStrategy : solvingStrategies) {
+            /* Delete object */
+            delete solvingStrategy;
+        }
     }
 };
 
@@ -44,7 +55,7 @@ protected:
  */
 TEST_F(DiagonalStrategyTests, validation_check_false_1) {
     /* Initialize input Matrix */
-    Matrix invalid = FileInputHandler{{false}, "invalid4.mat"}.readInput();
+    Matrix invalid = FileInputHandler{solvingStrategies, "invalid4.mat"}.readInput();
 
     /* Check validity
      * Should return false */
@@ -56,7 +67,7 @@ TEST_F(DiagonalStrategyTests, validation_check_false_1) {
  */
 TEST_F(DiagonalStrategyTests, validation_check_false_2) {
     /* Initialize input Matrix */
-    Matrix invalid = FileInputHandler{{false}, "invalid5.mat"}.readInput();
+    Matrix invalid = FileInputHandler{solvingStrategies, "invalid5.mat"}.readInput();
 
     /* Check validity
      * Should return false */

--- a/sudooku_tests/core_tests/strategy_tests/groupStrategyTest.cpp
+++ b/sudooku_tests/core_tests/strategy_tests/groupStrategyTest.cpp
@@ -2,6 +2,8 @@
 // Created by Borbély László on 2018. 10. 21..
 //
 
+#include <sudooku_core/strategies/rowStrategy.h>
+#include <sudooku_core/strategies/columnStrategy.h>
 #include <sudooku_core/strategies/groupStrategy.h>
 #include <sudooku_controller/handlers/input_handlers/fileInputHandler.h>
 #include "gtest/gtest.h"
@@ -13,18 +15,30 @@ class GroupStrategyTests : public ::testing::Test {
 protected:
     GroupStrategy groupStrategy;
     Matrix m1;
+    std::vector<SolvingStrategy *> solvingStrategies = {new RowStrategy{}, new ColumnStrategy{}, new GroupStrategy{}};
 
     /**
      * Setup method running before the execution of each test case
      */
     void SetUp() override {
         /* Initialize input Matrix */
-        m1 = FileInputHandler{{false}, "small3.mat"}.readInput();
+        m1 = FileInputHandler{solvingStrategies, "small3.mat"}.readInput();
 
         /* Remove some values to test group strategy functionality */
         m1[{1, 3}].removeValue(4);
         m1[{1, 4}].removeValue(4);
         m1[{2, 3}].removeValue(4);
+    }
+
+    /**
+     * Teardown method running after the execution of each test case
+     */
+    void TearDown() override {
+        /* Deallocate SolvingStrategy pointers */
+        for (SolvingStrategy *solvingStrategy : solvingStrategies) {
+            /* Delete object */
+            delete solvingStrategy;
+        }
     }
 };
 
@@ -33,7 +47,7 @@ protected:
  */
 TEST_F(GroupStrategyTests, validation_check_false) {
     /* Initialize input Matrix */
-    Matrix invalid = FileInputHandler{{false}, "invalid3.mat"}.readInput();
+    Matrix invalid = FileInputHandler{solvingStrategies, "invalid3.mat"}.readInput();
 
     /* Check validity
      * Should return false */

--- a/sudooku_tests/core_tests/strategy_tests/rowStrategyTest.cpp
+++ b/sudooku_tests/core_tests/strategy_tests/rowStrategyTest.cpp
@@ -3,6 +3,8 @@
 //
 
 #include <sudooku_core/strategies/rowStrategy.h>
+#include <sudooku_core/strategies/columnStrategy.h>
+#include <sudooku_core/strategies/groupStrategy.h>
 #include <sudooku_controller/handlers/input_handlers/fileInputHandler.h>
 #include "gtest/gtest.h"
 
@@ -13,18 +15,30 @@ class RowStrategyTests : public ::testing::Test {
 protected:
     RowStrategy rowStrategy;
     Matrix m1;
+    std::vector<SolvingStrategy *> solvingStrategies = {new RowStrategy{}, new ColumnStrategy{}, new GroupStrategy{}};
 
     /**
      * Setup method running before the execution of each test case
      */
     void SetUp() override {
         /* Initialize input Matrix */
-        m1 = FileInputHandler{{false}, "small2.mat"}.readInput();
+        m1 = FileInputHandler{solvingStrategies, "small2.mat"}.readInput();
 
         /* Remove some values to test row strategy functionality */
         m1[{2, 1}].removeValue(4);
         m1[{2, 2}].removeValue(4);
         m1[{2, 3}].removeValue(4);
+    }
+
+    /**
+     * Teardown method running after the execution of each test case
+     */
+    void TearDown() override {
+        /* Deallocate SolvingStrategy pointers */
+        for (SolvingStrategy *solvingStrategy : solvingStrategies) {
+            /* Delete object */
+            delete solvingStrategy;
+        }
     }
 };
 
@@ -34,7 +48,7 @@ protected:
  */
 TEST_F(RowStrategyTests, validation_check_false) {
     /* Initialize input Matrix */
-    Matrix invalid = FileInputHandler{{false}, "invalid2.mat"}.readInput();
+    Matrix invalid = FileInputHandler{solvingStrategies, "invalid2.mat"}.readInput();
 
     /* Check validity
      * Should return false */


### PR DESCRIPTION
To make memory handling easier to follow, the ```InputHandler``` and ```FileInputHandler``` classes were refactored. This means, now the memory allocation and the deallocation can (and should!) happen at the same location.